### PR TITLE
feat(project): Change name to Hrz.Returnables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Horizon Returnables (`HorizonCo.Returnables`) is a .NET 10 NuGet library implementing the Result/Error pattern for .NET applications — replacing exception-driven control flow with explicit return values.
+Horizon Returnables (`Hrz.Returnables`) is a .NET 10 NuGet library implementing the Result/Error pattern for .NET applications — replacing exception-driven control flow with explicit return values.
 
 ## Build Commands
 
@@ -35,7 +35,7 @@ dotnet format --verify-no-changes
 
 ## Architecture
 
-### `Horizon.Returnables` namespace
+### `Hrz.Returnables` namespace
 
 Lightweight `readonly struct` types using `Error` as the error carrier:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="icon.png" alt="Horizon Returnables" width="120" />
+  <img src="icon.png" alt="Hrz Returnables" width="120" />
 </p>
 
-<h1 align="center">Horizon Returnables</h1>
+<h1 align="center">Hrz Returnables</h1>
 
 <p align="center">
   A lightweight, zero-dependency Result/Error pattern library for .NET.<br/>
@@ -10,8 +10,8 @@
 </p>
 
 <p align="center">
-  <a href="https://nuget.org/packages/HorizonCo.Returnables"><img src="https://img.shields.io/nuget/v/HorizonCo.Returnables.svg?style=flat-square&logo=nuget&label=NuGet" alt="NuGet Version" /></a>
-  <a href="https://nuget.org/packages/HorizonCo.Returnables"><img src="https://img.shields.io/nuget/dt/HorizonCo.Returnables.svg?style=flat-square&logo=nuget&label=Downloads" alt="NuGet Downloads" /></a>
+  <a href="https://nuget.org/packages/Hrz.Returnables"><img src="https://img.shields.io/nuget/v/Hrz.Returnables.svg?style=flat-square&logo=nuget&label=NuGet" alt="NuGet Version" /></a>
+  <a href="https://nuget.org/packages/Hrz.Returnables"><img src="https://img.shields.io/nuget/dt/Hrz.Returnables.svg?style=flat-square&logo=nuget&label=Downloads" alt="NuGet Downloads" /></a>
   <a href="https://github.com/horizon-co/hrz-returnables/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/horizon-co/hrz-returnables/ci.yml?branch=main&style=flat-square&logo=github&label=CI" alt="CI Status" /></a>
   <a href="https://github.com/horizon-co/hrz-returnables/blob/main/LICENSE"><img src="https://img.shields.io/github/license/horizon-co/hrz-returnables?style=flat-square&label=License" alt="License" /></a>
 </p>
@@ -55,13 +55,13 @@ No wrapping. No `.Success(value)` calls. No factory noise. Just return the value
 ## Installation
 
 ```bash
-dotnet add package HorizonCo.Returnables
+dotnet add package Hrz.Returnables
 ```
 
 Or via the Package Manager:
 
 ```
-PM> Install-Package HorizonCo.Returnables
+PM> Install-Package Hrz.Returnables
 ```
 
 ## Quick Start

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet">
-    <PackageId>HorizonCo.Returnables</PackageId>
+    <PackageId>Hrz.Returnables</PackageId>
     <Title>Horizon Returnables — Result/Error Pattern for .NET</Title>
     <Description>A lightweight, zero-dependency Result pattern library for .NET. Replace exception-driven control flow with explicit, stack-allocated Result and Result&lt;T&gt; types featuring implicit operators, nullability flow analysis, Try/TryAsync wrappers, and fluent side-effects.</Description>
     <Authors>Horizon engineering team</Authors>
     <Company>Horizon Company</Company>
-    <Product>Horizon.Returnables</Product>
+    <Product>Hrz.Returnables</Product>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy")) Horizon Company</Copyright>
     <PackageTags>result;error;result-pattern;railway;monad;either;error-handling;returnables;dotnet;csharp</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This pull request updates the project and documentation to reflect a rebranding of the library from "Horizon Returnables" (`HorizonCo.Returnables`) to "Hrz Returnables" (`Hrz.Returnables`). The changes ensure consistency across documentation, badges, installation instructions, and NuGet configuration.

**Project and Documentation Rebranding:**

* Updated all references to the library name from `HorizonCo.Returnables` to `Hrz.Returnables` in the `README.md`, including badges, installation instructions, and the project title. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R64)
* Changed the namespace and project name references in `CLAUDE.md` to `Hrz.Returnables` for accuracy and consistency. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L7-R7) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L38-R38)
* Updated the NuGet package configuration in `src/Core/Core.csproj` to use `Hrz.Returnables` for `PackageId` and `Product` fields.