### PR TITLE
fix(project): Change Horizon namespace to Hrz

### DIFF
--- a/.claude/rules/csharp-architecture.md
+++ b/.claude/rules/csharp-architecture.md
@@ -11,7 +11,7 @@ src/Core/          → library source
 tests/Core.Tests/  → unit tests
 ```
 
-## Result Types — `Horizon.Returnables` namespace
+## Result Types — `Hrz.Returnables` namespace
 
 Lightweight `readonly struct` types using `Exception` as the error carrier:
 
@@ -35,7 +35,7 @@ Production project:
   <WarningsAsErrors>Nullable</WarningsAsErrors>
   <ImplicitUsings>enable</ImplicitUsings>
   <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  <RootNamespace>Horizon.Returnables.Core</RootNamespace>
+  <RootNamespace>Hrz.Returnables.Core</RootNamespace>
   <AssemblyName>$(RootNamespace)</AssemblyName>
 </PropertyGroup>
 ```
@@ -48,7 +48,7 @@ Test project:
   <Nullable>enable</Nullable>
   <WarningsAsErrors>Nullable</WarningsAsErrors>
   <ImplicitUsings>enable</ImplicitUsings>
-  <RootNamespace>Horizon.Returnables.Core.Tests</RootNamespace>
+  <RootNamespace>Hrz.Returnables.Core.Tests</RootNamespace>
 </PropertyGroup>
 ```
 

--- a/.claude/rules/csharp-code-style.md
+++ b/.claude/rules/csharp-code-style.md
@@ -15,7 +15,7 @@ Rules for writing C# code in this project. Apply these when generating, reviewin
 
 ```csharp
 // correct
-namespace Horizon.Returnables.Core.Errors;
+namespace Hrz.Returnables.Core.Errors;
 
 public record Error { }
 ```

--- a/.claude/rules/csharp-naming-conventions.md
+++ b/.claude/rules/csharp-naming-conventions.md
@@ -82,10 +82,10 @@ public enum ErrorType
 
 - PascalCase for each segment.
 - Mirror the project's folder structure exactly.
-- Format: `Horizon.Returnables`.
+- Format: `Hrz.Returnables`.
 
 ```csharp
-namespace Horizon.Returnables;
+namespace Hrz.Returnables;
 ```
 
 ## Test Naming

--- a/.claude/rules/dotnet-testing-conventions.md
+++ b/.claude/rules/dotnet-testing-conventions.md
@@ -63,7 +63,7 @@ Each component gets its own `{Component}UnitTests/` folder. **Each public method
 
 ```csharp
 // File: tests/Core.Tests/ResultUnitTests/FailUnitTests.cs
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 [Trait(nameof(Result), nameof(Result.Fail))]
 public sealed class FailUnitTests { }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Exceptions are expensive, invisible in method signatures, and easy to forget. Th
 Returnables gives you this pattern with **zero boilerplate**:
 
 ```csharp
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 public Result<User> GetUser(int id)
 {
@@ -71,7 +71,7 @@ PM> Install-Package Hrz.Returnables
 For commands and side-effects that don't return a value:
 
 ```csharp
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 public Result DeleteUser(int id)
 {

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -5,18 +5,18 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
-    <AssemblyName>Horizon.Returnables.Core</AssemblyName>
-    <RootNamespace>Horizon.Returnables.Core</RootNamespace>
+    <AssemblyName>Hrz.Returnables.Core</AssemblyName>
+    <RootNamespace>Hrz.Returnables.Core</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet">
-    <PackageId>Hrz.Returnables</PackageId>
+    <PackageId>Horizontal.Returnables</PackageId>
     <Title>Horizon Returnables — Result/Error Pattern for .NET</Title>
     <Description>A lightweight, zero-dependency Result pattern library for .NET. Replace exception-driven control flow with explicit, stack-allocated Result and Result&lt;T&gt; types featuring implicit operators, nullability flow analysis, Try/TryAsync wrappers, and fluent side-effects.</Description>
     <Authors>Horizon engineering team</Authors>
     <Company>Horizon Company</Company>
-    <Product>Hrz.Returnables</Product>
+    <Product>Horizontal.Returnables</Product>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy")) Horizon Company</Copyright>
     <PackageTags>result;error;result-pattern;railway;monad;either;error-handling;returnables;dotnet;csharp</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Core/Error.cs
+++ b/src/Core/Error.cs
@@ -1,4 +1,4 @@
-namespace Horizon.Returnables;
+namespace Hrz.Returnables;
 
 /// <summary>
 /// Represents an error with a code and a message.

--- a/src/Core/Result.cs
+++ b/src/Core/Result.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Horizon.Returnables;
+namespace Hrz.Returnables;
 
 /// <summary>
 /// Represents the outcome of an operation that does not return a value.

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -6,7 +6,7 @@
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <RootNamespace>Horizon.Returnables.Core.Tests</RootNamespace>
+    <RootNamespace>Hrz.Returnables.Core.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Core.Tests/ResultTUnitTests/FailIfUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/FailIfUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/FailUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/FailUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/FailureUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/FailureUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/FromUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/FromUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/ImplicitOperatorUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/ImplicitOperatorUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/OnFailureUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/OnFailureUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/OnSuccessUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/OnSuccessUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/SucceededUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/SucceededUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/SuccessIfUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/SuccessIfUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/SwitchUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/SwitchUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/TryAsyncUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/TryAsyncUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultTUnitTests/TryUnitTests.cs
+++ b/tests/Core.Tests/ResultTUnitTests/TryUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultTUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultTUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/FailIfUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/FailIfUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/FailUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/FailUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/FailureUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/FailureUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/FromUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/FromUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/ImplicitOperatorUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/ImplicitOperatorUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/OnFailureUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/OnFailureUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/OnSuccessUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/OnSuccessUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/SuccessIfUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/SuccessIfUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/SuccessUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/SuccessUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/SwitchUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/SwitchUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/TryAsyncUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/TryAsyncUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 

--- a/tests/Core.Tests/ResultUnitTests/TryUnitTests.cs
+++ b/tests/Core.Tests/ResultUnitTests/TryUnitTests.cs
@@ -1,8 +1,8 @@
-namespace Horizon.Returnables.Core.Tests.ResultUnitTests;
+namespace Hrz.Returnables.Core.Tests.ResultUnitTests;
 
 using FluentAssertions;
 
-using Horizon.Returnables;
+using Hrz.Returnables;
 
 using Xunit;
 


### PR DESCRIPTION
This pull request performs a comprehensive namespace renaming throughout the codebase and documentation, changing all references from `Horizon.Returnables` to `Hrz.Returnables`. It also updates related project metadata, such as root namespaces and package identifiers, to align with the new naming convention. Additionally, some package IDs and product names are updated to use "Horizontal" instead of the abbreviated form. These changes ensure consistency across source files, tests, documentation, and project configuration.

**Namespace and Identifier Renaming:**

* Renamed all code and test namespaces from `Horizon.Returnables` to `Hrz.Returnables` in both source files (e.g., `Error.cs`, `Result.cs`) and test files (e.g., all files in `tests/Core.Tests/ResultTUnitTests/`). [[1]](diffhunk://#diff-899ba3ffb5c9714737bcb1b9f50730930f306aba476d1caa47491e7a49e40dd7L1-R1) [[2]](diffhunk://#diff-0f3108fa516b53e06965b336b9d59602e15450cd7ac92c2bbd0f901a946ebc17L3-R3) [[3]](diffhunk://#diff-dcb4d91d701686680cb22fbf0499ef583e6a0132c089169e7b42d1e3d7b1332eL1-R5) [[4]](diffhunk://#diff-d17d1bd259d8fabc0c3d4e7ec360a77619ca393051703b8d11da644665f5dd54L1-R5) [[5]](diffhunk://#diff-80ae85476e0bd7c03a40d4bb72f00eb38026568ff1c99a516215f952ff68b2b6L1-R5) [[6]](diffhunk://#diff-edbb41b4c2f2b986c60172954972d3100091f4a46d69648ff361e99f94b0bfd3L1-R5) [[7]](diffhunk://#diff-1f1adb30d81dc957f0459961aea0a9121889017b1360be8d4f66e18344ee5144L1-R5) [[8]](diffhunk://#diff-5974f8858b2bc15dd5502f7cf36a7a1acde1da8c0c7ec3e82b12be8fca38f1deL1-R5) [[9]](diffhunk://#diff-690f43ba3d115c9b48e91a17456f13d66bc438e67947fc6746c2ea7623eef3f2L1-R5) [[10]](diffhunk://#diff-3954f866034550c12560f7d3124c6f0f3ad7f63c9ca6afeb5661a9a614a505b3L1-R5) [[11]](diffhunk://#diff-6ea1e2b119b7b1a3b0961a4a1daeadfb94911854500ec1989372202437db1950L1-R5) [[12]](diffhunk://#diff-b95068b3ca234dad0d77303e1fdde1f847857c336d11b720e45c956f6c1f83e7L1-R5) [[13]](diffhunk://#diff-abe8c3bca01d2fd0c7f01bf7932d031ec4d3943126a31c606a374093fd687a15L1-R5)
* Updated all `using` directives and namespace declarations in documentation, markdown, and code style/conventions files to use `Hrz.Returnables` instead of `Horizon.Returnables`. [[1]](diffhunk://#diff-ea9119183b7f21c772d0a33792c16ebff7e5c0bf12437bbb2cbe1231c23bea4eL14-R14) [[2]](diffhunk://#diff-25d1d9f350bb8c781afe74460f15f8f16c1cf3f81b8604c83b57ff8800724608L18-R18) [[3]](diffhunk://#diff-37b03ab5dd4584ea5af74b61294b40bc839b58accb81165bd866a3b102c985f4L85-R88) [[4]](diffhunk://#diff-4a221580aaf9c38e6ab3e713c0ada796e296d6cc3c15419b4c9ea7dfd638a75bL66-R66) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L74-R74)

**Project and Package Metadata Updates:**

* Changed the `RootNamespace` and `AssemblyName` in both production (`src/Core/Core.csproj`) and test (`tests/Core.Tests/Core.Tests.csproj`) projects to `Hrz.Returnables.Core` and `Hrz.Returnables.Core.Tests`, respectively. [[1]](diffhunk://#diff-4376ed2659b7ce2106044ede2c89107e1e9e47805b39ce87551565888ece54eaL8-R19) [[2]](diffhunk://#diff-9fa45e35977d5e45281a5df69ee75b66ce19e997471afaf20add3dfa6e52c704L9-R9) [[3]](diffhunk://#diff-ea9119183b7f21c772d0a33792c16ebff7e5c0bf12437bbb2cbe1231c23bea4eL38-R38) [[4]](diffhunk://#diff-ea9119183b7f21c772d0a33792c16ebff7e5c0bf12437bbb2cbe1231c23bea4eL51-R51)
* Updated the NuGet `PackageId` and `Product` fields from `Hrz.Returnables` to `Horizontal.Returnables` to match new branding.

These changes ensure a consistent and updated naming convention across the entire project.