### PR TITLE
fix(package): Fixing package name

### DIFF
--- a/.claude/rules/csharp-architecture.md
+++ b/.claude/rules/csharp-architecture.md
@@ -2,7 +2,7 @@
 
 ## Project Type
 
-This is a **NuGet library package** (`HorizonCo.Returnables`), not a web application. There are no controllers, middleware, DI, or infrastructure layers. The library provides Result/Error types consumed by other Horizon projects.
+This is a **NuGet library package** (`Hrz.Returnables`), not a web application. There are no controllers, middleware, DI, or infrastructure layers. The library provides Result/Error types consumed by other Horizon projects.
 
 ## Project Structure
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet">
-    <PackageId>Horizontal.Returnables</PackageId>
+    <PackageId>Hrz.Returnables</PackageId>
     <Title>Horizon Returnables — Result/Error Pattern for .NET</Title>
     <Description>A lightweight, zero-dependency Result pattern library for .NET. Replace exception-driven control flow with explicit, stack-allocated Result and Result&lt;T&gt; types featuring implicit operators, nullability flow analysis, Try/TryAsync wrappers, and fluent side-effects.</Description>
     <Authors>Horizon engineering team</Authors>
     <Company>Horizon Company</Company>
-    <Product>Horizontal.Returnables</Product>
+    <Product>Hrz.Returnables</Product>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy")) Horizon Company</Copyright>
     <PackageTags>result;error;result-pattern;railway;monad;either;error-handling;returnables;dotnet;csharp</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This pull request updates the NuGet package name and related identifiers from "Horizontal.Returnables" to "Hrz.Returnables" across the project. This ensures consistency in package naming and branding.

NuGet package renaming:

* Changed the `PackageId` and `Product` fields in `Core.csproj` from `Horizontal.Returnables` to `Hrz.Returnables`.

Documentation update:

* Updated the project type description in `.claude/rules/csharp-architecture.md` to reference `Hrz.Returnables` instead of `HorizonCo.Returnables`.